### PR TITLE
Dependency update, capture seed-based flag generations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "cli"
 
 [dependencies]
 # Our async runtime
-tokio = { version = "1.40", default-features = false, features = [
+tokio = { version = "1.43", default-features = false, features = [
     "macros",
     "rt-multi-thread",
 ] }
@@ -16,34 +16,41 @@ tokio = { version = "1.40", default-features = false, features = [
 # Crypto
 sha3 = "0.10"
 hmac = "0.12"
-rand = "0.8"
+rand = "0.9"
 
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 toml = "0.8"
 
 # Cli
-itertools = "0.13.0"
+itertools = "0.14.0"
 clap = { version = "4.5", features = ["derive", "cargo"] }
-thiserror = "1.0.63"
-tracing = { version = "0.1.40" }
-tracing-subscriber = { version = "0.3.18", features = [] }
-aws-sdk-s3 = { version = "1.49.0", default-features = false, features = [
+thiserror = "2"
+tracing = { version = "0.1.41" }
+tracing-subscriber = { version = "0.3.19", features = [] }
+aws-sdk-s3 = { version = "1.76.0", default-features = false, features = [
     "rt-tokio",
 ] }
-aws-config = { version = "1.5.6", default-features = false, features = [
+aws-config = { version = "1.5.16", default-features = false, features = [
     "client-hyper",
     "rt-tokio",
     "rustls",
 ] }
-futures = "0.3.30"
-moodle-xml = "0.1.1"
-serde_json = "1.0.128"
-once_cell = { version = "1.19.0", default-features = false }
-tempfile = { version = "3.12.0", default-features = false }
+futures = "0.3.31"
+moodle-xml = "0.2.0"
+serde_json = "1"
+once_cell = { version = "1", default-features = false }
+tempfile = { version = "3", default-features = false }
 [dependencies.uuid]
-version = "1.9"
+version = "1"
 features = [
     "v7",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
 ]
+
+[dev-dependencies]
+insta = { version = "1.42.1", features = ["yaml"] }
+
+[profile.dev.package]
+insta.opt-level = 3
+similar.opt-level = 3

--- a/src/bin/cli.rs
+++ b/src/bin/cli.rs
@@ -192,10 +192,10 @@ impl OutputDirectory {
 
 fn main() -> std::process::ExitCode {
     // Global stdout subscriber for event tracing, defaults to info level
-    let subscriber = tracing_subscriber::FmtSubscriber::new();
-    // let subscriber = tracing_subscriber::FmtSubscriber::builder()
-    //     .with_max_level(tracing::Level::DEBUG) // Set log level to DEBUG
-    //     .finish();
+    // let subscriber = tracing_subscriber::FmtSubscriber::new();
+    let subscriber = tracing_subscriber::FmtSubscriber::builder()
+        .with_max_level(tracing::Level::DEBUG) // Set log level to DEBUG
+        .finish();
     tracing::subscriber::set_global_default(subscriber).unwrap();
 
     let cli = OptsRoot::parse();
@@ -207,7 +207,7 @@ fn main() -> std::process::ExitCode {
                 .to_str()
                 .unwrap_or("The configuration file does not have valid path name. Broken Unicode or something else.")
         );
-        std::process::exit(1);
+        ExitCode::FAILURE
     } else {
         match &cli.command {
             Commands::Generate {

--- a/src/build_process.rs
+++ b/src/build_process.rs
@@ -267,7 +267,7 @@ pub fn build_task(
                             Ok(file) => file,
                             Err(e) => {
                                 tracing::error!(
-                                    "Failed to open seeded_flags.json for task {}: {}",
+                                    "Failed to open flags.json for task {}: {}",
                                     task_config.id,
                                     e
                                 );

--- a/src/build_process.rs
+++ b/src/build_process.rs
@@ -3,7 +3,9 @@ use std::fs;
 use std::path::Path;
 use uuid::Uuid;
 
-use crate::config::{BuildConfig, Builder, ModuleConfiguration, OutputKind, Task};
+use crate::config::{
+    BuildConfig, Builder, ModuleConfiguration, OutputKind, Task, DEFAULT_FLAGS_FILENAME,
+};
 use crate::flag_generator::Flag;
 
 fn create_flag_id_pairs_by_task<'a>(
@@ -155,7 +157,8 @@ pub fn build_task(
     uuid: Uuid,
     output_directory: &Path,
 ) -> Result<TaskBuildProcessOutput, Box<dyn std::error::Error>> {
-    let (flags, mut build_envs) = create_flag_id_pairs_by_task(task_config, module_config, uuid);
+    let (mut flags, mut build_envs) =
+        create_flag_id_pairs_by_task(task_config, module_config, uuid);
 
     match task_config.build.builder {
         Builder::Shell(ref entrypoint) => {
@@ -207,9 +210,26 @@ pub fn build_task(
             let mut outputs = Vec::with_capacity(task_config.build.output.len());
             if output.status.success() {
                 for output in &task_config.build.output {
-                    let path = builder_output_dir
+                    let path = match builder_output_dir
                         .join(output.kind.get_filename())
-                        .canonicalize()?;
+                        .canonicalize()
+                    {
+                        Ok(p) => {
+                            tracing::debug!(
+                                "Constructed path when checking build output files: {}",
+                                p.display()
+                            );
+                            p
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to canonicalize build output path for file {}: {}",
+                                &output.kind.get_filename().to_string_lossy(),
+                                e
+                            );
+                            return Err(Box::new(e));
+                        }
+                    };
                     match fs::metadata(&path) {
                         Ok(_) => {
                             tracing::debug!("File exists: {}", path.display());
@@ -225,6 +245,52 @@ pub fn build_task(
                             std::process::exit(1);
                         }
                     }
+                }
+                // If the task has a seed-based flag, we must capture the resulting flag from the process output
+                // Stored into the file seeded_flags.json, using same key as the passed environment variable
+                for flag in flags.iter_mut() {
+                    let flag_key = flag.get_flag_type_value_pair().0;
+                    if let Flag::UserSeedFlag(ref mut user_seed_flag) = flag {
+                        let path = task_config
+                            .build
+                            .output
+                            .iter()
+                            .find_map(|output| {
+                                if let OutputKind::Flags(ref pathbuf) = output.kind {
+                                    Some(builder_output_dir.join(pathbuf))
+                                } else {
+                                    None
+                                }
+                            })
+                            .unwrap_or_else(|| builder_output_dir.join(DEFAULT_FLAGS_FILENAME));
+                        let file = match fs::File::open(&path) {
+                            Ok(file) => file,
+                            Err(e) => {
+                                tracing::error!(
+                                    "Failed to open seeded_flags.json for task {}: {}",
+                                    task_config.id,
+                                    e
+                                );
+                                std::process::exit(1);
+                            }
+                        };
+                        let reader = std::io::BufReader::new(file);
+                        let seeded_flags: HashMap<String, String> =
+                            serde_json::from_reader(reader)?;
+                        // Same key than passed for the build process
+                        if let Some(seed) = seeded_flags.get(&flag_key) {
+                            user_seed_flag.update_suffix(seed.to_owned());
+                        } else {
+                            tracing::error!(
+                                "Seed flag for task {} not found in the output file",
+                                task_config.id
+                            );
+                            std::process::exit(1);
+                        }
+                    }
+                }
+                for flag in &flags {
+                    tracing::debug!("Flag: {:?}", flag);
                 }
                 Ok(TaskBuildProcessOutput::new(
                     uuid,

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 const DEFAULT_NIX_FILENAME: &str = "flake.nix";
 const DEFAULT_SH_FILENAME: &str = "entrypoint.sh";
+pub(crate) const DEFAULT_FLAGS_FILENAME: &str = "flags.json";
 
 #[derive(Debug, Error)]
 pub enum ConfigError {
@@ -237,6 +238,7 @@ pub enum OutputKind {
     Resource(PathBuf),
     Readme(PathBuf),
     Meta(PathBuf),
+    Flags(PathBuf),
 }
 
 impl OutputKind {
@@ -246,6 +248,7 @@ impl OutputKind {
             OutputKind::Resource(_) => OutputKind::Resource(new_content),
             OutputKind::Readme(_) => OutputKind::Readme(new_content),
             OutputKind::Meta(_) => OutputKind::Meta(new_content),
+            OutputKind::Flags(_) => OutputKind::Flags(new_content),
         }
     }
     pub fn get_filename(&self) -> &Path {
@@ -254,6 +257,7 @@ impl OutputKind {
             OutputKind::Resource(name) => name,
             OutputKind::Readme(name) => name,
             OutputKind::Meta(name) => name,
+            OutputKind::Flags(_) => Path::new(DEFAULT_FLAGS_FILENAME),
         }
     }
     pub const fn kind(&self) -> &str {
@@ -262,6 +266,7 @@ impl OutputKind {
             OutputKind::Resource(_) => "resource",
             OutputKind::Readme(_) => "readme",
             OutputKind::Meta(_) => "meta",
+            OutputKind::Flags(_) => "flags",
         }
     }
 }

--- a/src/flag_generator.rs
+++ b/src/flag_generator.rs
@@ -122,6 +122,9 @@ impl FlagUnit {
             suffix: flag_suffix_result,
         }
     }
+    pub fn update_suffix(&mut self, new_suffix: String) {
+        self.suffix = new_suffix;
+    }
 
     fn user_flag(
         identifier: String,
@@ -149,11 +152,11 @@ impl FlagUnit {
 
 /// Generates a completely random flag
 fn pure_random_flag(lenght: u8) -> String {
-    let mut rng = StdRng::from_entropy();
+    let mut rng = StdRng::from_os_rng();
     let size = lenght.into();
     let mut vec: Vec<u8> = vec![0; size];
     for i in &mut vec {
-        *i = rng.gen();
+        *i = rng.random();
     }
     vec.iter().fold(String::new(), |mut output, b| {
         let _ = write!(output, "{b:02x}");

--- a/src/flag_generator.rs
+++ b/src/flag_generator.rs
@@ -122,6 +122,9 @@ impl FlagUnit {
             suffix: flag_suffix_result,
         }
     }
+    pub fn value(&self) -> &str {
+        self.suffix.as_str()
+    }
     pub fn update_suffix(&mut self, new_suffix: String) {
         self.suffix = new_suffix;
     }

--- a/src/moodle.rs
+++ b/src/moodle.rs
@@ -110,7 +110,7 @@ fn process_multiple_flags(flags: Vec<Flag>, separator: &str) -> Vec<Answer> {
                 let combined_answer = join_flags(&perm_flags, separator); // Pass as a slice
 
                 // Calculate points based on the number of flags
-                let points = ((r as f64 / total_flags as f64) * 100.0).round() as u8;
+                let points = ((r as f64 / total_flags as f64) * 100.0).round() as i8;
 
                 answers.push(Answer::new(
                     points,

--- a/src/moodle.rs
+++ b/src/moodle.rs
@@ -52,18 +52,27 @@ pub fn create_exam(
                 let mut question =
                     ShortAnswerQuestion::new(task_config.name.clone(), instructions_string, None);
                 let answers = if item.flags.len() == 1 {
-                    vec![
-                        Answer::new(
+                    // Unknown flag, task build process has created this one
+                    if let Flag::UserSeedFlag(flag) = &item.flags[0] {
+                        vec![Answer::new(
                             100,
-                            item.flags[0].encase_flag(),
+                            flag.value().to_string(),
                             "Correct!".to_string().into(),
-                        ),
-                        Answer::new(
-                            100,
-                            item.flags[0].flag_string(),
-                            "Correct!".to_string().into(),
-                        ),
-                    ]
+                        )]
+                    } else {
+                        vec![
+                            Answer::new(
+                                100,
+                                item.flags[0].encase_flag(),
+                                "Correct!".to_string().into(),
+                            ),
+                            Answer::new(
+                                100,
+                                item.flags[0].flag_string(),
+                                "Correct!".to_string().into(),
+                            ),
+                        ]
+                    }
                 } else {
                     // Adds 1-inf flags as answer with chosen separator
                     process_multiple_flags(item.flags.clone(), " ")
@@ -88,7 +97,16 @@ pub fn create_exam(
 
 // Function to encase each flag with a specified separator
 fn encase_each_flag(flags: &[Flag], separator: &str) -> String {
-    flags.iter().map(|f| f.encase_flag()).join(separator)
+    flags
+        .iter()
+        .map(|f| {
+            if let Flag::UserSeedFlag(flag) = f {
+                flag.value().to_string()
+            } else {
+                f.encase_flag()
+            }
+        })
+        .join(separator)
 }
 
 // Function to join flags without encasing them

--- a/src/storages/s3.rs
+++ b/src/storages/s3.rs
@@ -138,6 +138,12 @@ impl CloudStorage for S3Storage {
             let file_key = format!("{}/{}", files.dst_location.trim_end_matches("/"), file.0);
             // Use structured concurrency whenever possible
             // Avoid using tokio::spawn, as we lose the control
+            // debug filename and path
+            tracing::debug!(
+                "Uploading with remote file key: {} from local path : {}",
+                file_key,
+                file.1.kind.get_filename().to_string_lossy()
+            );
             let body = ByteStream::from_path(file.1.kind.get_filename()).await;
             let task = async {
                 match body {
@@ -203,6 +209,10 @@ impl CloudStorage for S3Storage {
                                 }
                             }
                             Err(e) => {
+                                tracing::error!(
+                                    "Failed to upload the file: {:?}",
+                                    e.raw_response()
+                                );
                                 tracing::error!("Failed to upload the file: {}", e);
                                 return Err(CloudStorageError::AWSSdkError(e.to_string()));
                             }


### PR DESCRIPTION
Fixes #21 

When the seed is passed for the underlying builder process, initiator also captures the flag that was generated by using this seed. It currently uses `flag.json` in the build output directory. Previously the seed itself was used as "correct" flag, now it is the resulting value. 